### PR TITLE
sty file: Remove old dependencies, cleanup code

### DIFF
--- a/lua-check-hyphen.sty
+++ b/lua-check-hyphen.sty
@@ -21,11 +21,11 @@
 
 \def\luachekchyphendothings{\directlua{luachekchyphen.enable() }}
 
-\define@key{luacheckhyphen}{nofile}[true]{\directlua{luachekchyphen.nofile  = "\luatexluaescapestring{#1}"}}
-\define@key{luacheckhyphen}{compact}[true]{\directlua{luachekchyphen.compact  = "\luatexluaescapestring{#1}"}}
-\define@key{luacheckhyphen}{final}[true]{\directlua{luachekchyphen.final  = "\luatexluaescapestring{#1}"}}
-\define@key{luacheckhyphen}{mark}[true]{\directlua{luachekchyphen.mark     = "\luatexluaescapestring{#1}"}}
-\define@key{luacheckhyphen}{whitelist}{\directlua{luachekchyphen.whitelist = "\luatexluaescapestring{#1}"}}
+\define@key{luacheckhyphen}{nofile}[true]{\directlua{luachekchyphen.nofile  = "\luaescapestring{#1}"}}
+\define@key{luacheckhyphen}{compact}[true]{\directlua{luachekchyphen.compact  = "\luaescapestring{#1}"}}
+\define@key{luacheckhyphen}{final}[true]{\directlua{luachekchyphen.final  = "\luaescapestring{#1}"}}
+\define@key{luacheckhyphen}{mark}[true]{\directlua{luachekchyphen.mark     = "\luaescapestring{#1}"}}
+\define@key{luacheckhyphen}{whitelist}{\directlua{luachekchyphen.whitelist = "\luaescapestring{#1}"}}
 
 
 \ifluatex

--- a/lua-check-hyphen.sty
+++ b/lua-check-hyphen.sty
@@ -7,8 +7,7 @@
 
 
 \RequirePackage{ifluatex}
-\RequirePackage{luatexbase-attr}
-\RequirePackage{luatextra}
+\RequirePackage{luatexbase}
 \RequirePackage{keyval}
 
 \DeclareOption{final}{\setkeys{luacheckhyphen}{final}}


### PR DESCRIPTION
`luatexbase-attr` is now just a dummy loader for `luatexbase`.

`luatextra` is pretty outdated (hasn't seen an update for 7 years, way before LuaTeX became stable) and pulls in very old dependencies, which
are not needed any more. In fact, [`luatextra`](http://mirrors.sorengard.com/ctan/macros/luatex/latex/luatextra/) does nothing more than pulling in these dependencies:
```
\RequirePackage{fontspec}
\RequirePackage{luatexbase}
\RequireLuaModule{lualibs}
\RequirePackage{metalogo}
\RequirePackage{luacode}
\RequirePackage{fixltx2e}
```
(Source: http://mirrors.sorengard.com/ctan/macros/luatex/latex/luatextra/luatextra.dtx)

Out of these
* `fontspec` is not used by `lua-check-hyphen`
* `luatexbase` is already being required by `lua-check-hyphen`
* `ifluatex` is already being required by `lua-check-hyphen`
* `lualibs` is not being used
* `metalogo` is not being used
* `luacode` is not being used
* `fixltx2e` is deprecated. Loading it results in a warning that the fixes it provides are no longer necessary since 2015.

`\luatexluaescapestring` is just another name for `\luaescapestring` nowadays anyway:
```
\let\luatexluaescapestring\luaescapestring
```
See http://ctan.mirrors.hoobly.com/macros/luatex/generic/luatexbase/luatexbase.dtx line 803.





